### PR TITLE
Initialize transcoder field if set in config

### DIFF
--- a/Amazon.ElastiCacheCluster/ElastiCacheClusterConfig.cs
+++ b/Amazon.ElastiCacheCluster/ElastiCacheClusterConfig.cs
@@ -113,7 +113,12 @@ namespace Amazon.ElastiCacheCluster
             this.Authentication = (IAuthenticationConfiguration)setup.Authentication ?? new AuthenticationConfiguration();
 
             this.nodeFactory = setup.NodeFactory ?? new DefaultConfigNodeFactory();
-
+            
+            if (setup.Transcoder != null)
+            {
+                this.transcoder = setup.Transcoder.CreateInstance() ?? new DefaultTranscoder();
+            }
+            
             if (setup.ClusterEndPoint.HostName.IndexOf(".cfg", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 if (setup.ClusterNode != null)


### PR DESCRIPTION
Noticed that the ElastiCacheClusterConfig class was ignoring the the transcoder config setting and would always be set to DefaultTranscoder. 
