### PR TITLE
Node Locator config setting not used

### DIFF
--- a/Amazon.ElastiCacheCluster/ElastiCacheClusterConfig.cs
+++ b/Amazon.ElastiCacheCluster/ElastiCacheClusterConfig.cs
@@ -113,6 +113,7 @@ namespace Amazon.ElastiCacheCluster
             this.Authentication = (IAuthenticationConfiguration)setup.Authentication ?? new AuthenticationConfiguration();
 
             this.nodeFactory = setup.NodeFactory ?? new DefaultConfigNodeFactory();
+            this.nodeLocator = setup.NodeLocator != null ? setup.NodeLocator.Type : typeof(DefaultNodeLocator);
             
             if (setup.Transcoder != null)
             {


### PR DESCRIPTION
Fixed issue where locators specified in the config file weren't used and DefaultNodeLocator was used instead.
